### PR TITLE
Refresh profile README around Open Delivery Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 [jenkinsci]: https://github.com/jenkinsci
 [pypa]: https://github.com/pypa
 [python]: https://github.com/python
-[python-prs]: https://github.com/pulls?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apypa+user%3Apython
+[python-prs]: https://github.com/pulls/search?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apypa+OR+user%3Apython
 [pypistats]: https://shenxianpeng.github.io/en/portfolio/pypistats/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@
 
 AI makes coding faster, but delivery still needs governance.
 
-I build **Open Delivery Stack**, an open-source toolkit for **AI-era software delivery**: standards, release readiness, delivery evidence, CI feedback, supply-chain safety, failure diagnosis, and maintainer automation.
+I build open-source tools for **DevOps, CI/CD, developer workflows, and AI-era software delivery**.
 
-Most of my projects are connected by one idea: help teams move from "AI generated code" to "software that is reviewed, governed, released, and improved with evidence."
+My projects focus on a practical question: how can teams make software delivery more consistent, explainable, and maintainable?
 
-#### The Solution Map
+That work comes together as **Open Delivery Stack**: a pragmatic toolkit for standards, quality gates, CI feedback, dependency safety, engineering signals, failure diagnosis, and maintainer automation.
 
-| Stage | Problem | Projects |
+AI is becoming part of that story, especially for explaining failures, assisting maintainers, reviewing changes, and improving how teams release software with evidence.
+
+#### Software Delivery Toolkit
+
+| Area | Problem | Projects |
 | --- | --- | --- |
 | Define engineering standards | Teams need consistent branch names, commit metadata, and contribution signals before work enters CI. | [conventional-branch][conventional-branch], [commit-check][commit-check] |
 | Shift quality left | Developers should catch C/C++, Jenkinsfile, and Dockerfile issues before review. | [cpp-linter-action][cpp-linter-action], [cpp-linter-hooks][cpp-linter-hooks], [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
@@ -28,14 +32,18 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 | Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion] |
 | Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [atlassian-api-py][atlassian-api-py] |
 
-#### Featured Systems
+#### Featured Tooling
 
-- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and AI-aware contribution workflows.
+- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and contribution workflows.
 - The [**cpp-linter**][cpp-linter-org] ecosystem brings C/C++ quality checks into GitHub Actions and pre-commit workflows, backed by maintained clang tools packaging across [static binaries][clang-tools-static-binaries], [Docker images][clang-tools-docker], and [Python wheels][clang-tools-wheel].
-- [**Explain Error Plugin**][explain-error-plugin] brings AI failure explanation and auto-fix workflows into Jenkins, with support for multiple AI providers.
 - [**pipguard**][pipguard] blocks risky Python package installation paths before supply-chain attacks land.
-- [**repokeeper**][repokeeper] explores an AI-powered maintainer loop: read issues, reason about code, open pull requests, and keep OSS projects alive.
 - [**gitstats**][gitstats], [**badgepy**][badgepy], and [**devops-maturity**][devops-maturity] convert engineering activity into reports, badges, and maturity signals that teams can act on.
+
+#### AI Experiments and Direction
+
+- [**Explain Error Plugin**][explain-error-plugin] applies AI to a concrete CI/CD pain point: turning Jenkins logs into causes, explanations, and suggested fixes.
+- [**repokeeper**][repokeeper] and [**aion**][aion] explore how agents can help maintainers triage work, reason about code, and keep repositories healthy.
+- My AI work is grounded in delivery workflows, not standalone demos: failure explanation, maintainer assistance, change review, and release evidence.
 
 #### Current Focus
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 #### Community and Stewardship
 
 - Member and contributor in the [**Jenkins**][jenkinsci] ecosystem, including [AI-powered Jenkins failure diagnosis][explain-error-plugin].
-- Contributor to [**PyPA**][pypa] and [**Python**][python] with [merged PRs][python-prs].
+- Contributor to [**PyPA**][pypa] ([merged PRs][pypa-prs]) and [**Python**][python] ([merged PRs][python-prs]).
 - Maintainer of [**mkdocs-ng/mkdocs**][mkdocs] and [**mkdocs-ng/mkdocs-material**][mkdocs-material].
 - Maintainer of developer productivity projects such as [**gitstats**][gitstats] and [**badgepy**][badgepy].
 
@@ -104,5 +104,6 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 [jenkinsci]: https://github.com/jenkinsci
 [pypa]: https://github.com/pypa
 [python]: https://github.com/python
-[python-prs]: https://github.com/pulls/search?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apypa+OR+user%3Apython
+[pypa-prs]: https://github.com/pulls/search?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apypa
+[python-prs]: https://github.com/pulls/search?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apython
 [pypistats]: https://shenxianpeng.github.io/en/portfolio/pypistats/

--- a/README.md
+++ b/README.md
@@ -10,30 +10,37 @@
 
 ---
 
-I build open-source tools for **AI-assisted software delivery**: standards, code quality, CI feedback, supply-chain safety, failure diagnosis, and maintainer automation.
+AI makes coding faster, but delivery still needs governance.
 
-Most of my projects are connected by one idea: help teams move from "we have many tools" to "we have an engineering system that guides, checks, explains, and improves itself."
+I build **Open Delivery Stack**, an open-source toolkit for **AI-era software delivery**: standards, release readiness, delivery evidence, CI feedback, supply-chain safety, failure diagnosis, and maintainer automation.
+
+Most of my projects are connected by one idea: help teams move from "AI generated code" to "software that is reviewed, governed, released, and improved with evidence."
 
 #### The Solution Map
 
 | Stage | Problem | Projects |
 | --- | --- | --- |
-| Define engineering standards | Teams need consistent branch names, commit metadata, and contribution signals before work enters CI. | [conventional-branch][conventional-branch], [commit-check][commit-check], [commit-check-action][commit-check-action], [commit-check-app][commit-check-app], [commit-check-mcp][commit-check-mcp] |
-| Shift quality left | Developers should catch formatting, static analysis, Dockerfile, and Jenkinsfile issues before review. | [cpp-linter][cpp-linter], [cpp-linter-hooks][cpp-linter-hooks], [cpp-linter-action][cpp-linter-action], [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
-| Secure and sustain dependencies | Supply-chain and runtime-version risks should be visible before they become production problems. | [pipguard][pipguard], [py-eol][py-eol], [gnuplot-wheel][gnuplot-wheel] |
-| Understand engineering systems | Teams need readable signals about repository health, delivery maturity, and generated quality reports. | [gitstats][gitstats], [badgepy][badgepy], [devops-maturity][devops-maturity] |
+| Define engineering standards | Teams need consistent branch names, commit metadata, and contribution signals before work enters CI. | [conventional-branch][conventional-branch], [commit-check][commit-check] |
+| Shift quality left | Developers should catch Jenkinsfile and Dockerfile issues before review. | [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
+| Secure and sustain dependencies | Supply-chain and runtime-version risks should be visible before they become production problems. | [pipguard][pipguard], [py-eol][py-eol] |
+| Understand engineering systems | Teams need readable signals about repository health, delivery maturity, and generated quality reports. | [gitstats][gitstats], [devops-maturity][devops-maturity] |
 | Diagnose CI/CD failures with AI | Build failures should come with context, likely causes, and next actions instead of raw logs only. | [jenkinsci/explain-error-plugin][explain-error-plugin] |
-| Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion], [atop][atop] |
-| Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [castops/cast-slice][cast-slice], [atlassian-api-py][atlassian-api-py] |
+| Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion] |
+| Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [atlassian-api-py][atlassian-api-py] |
 
 #### Featured Systems
 
-- [**cpp-linter**][cpp-linter] turns clang-format and clang-tidy into reusable developer workflows across CLI, GitHub Actions, pre-commit hooks, containers, and installable clang tools.
-- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to GitHub Actions, Apps, and MCP integrations.
+- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and AI-aware contribution workflows.
 - [**Explain Error Plugin**][explain-error-plugin] brings AI failure explanation and auto-fix workflows into Jenkins, with support for multiple AI providers.
 - [**pipguard**][pipguard] blocks risky Python package installation paths before supply-chain attacks land.
 - [**repokeeper**][repokeeper] explores an AI-powered maintainer loop: read issues, reason about code, open pull requests, and keep OSS projects alive.
 - [**gitstats**][gitstats], [**badgepy**][badgepy], and [**devops-maturity**][devops-maturity] convert engineering activity into reports, badges, and maturity signals that teams can act on.
+
+#### Current Focus
+
+- **Release readiness** - making it easier to know whether a change is ready to ship, not just whether tests passed.
+- **Delivery evidence** - turning repository, CI, dependency, and review signals into evidence teams can use for audits, releases, and retrospectives.
+- **AI-generated change governance** - building guardrails for AI-authored code so teams can review, trust, and maintain it over time.
 
 #### Community and Stewardship
 
@@ -51,7 +58,6 @@ Most of my projects are connected by one idea: help teams move from "we have man
 #### Writing
 
 <!-- BLOG-POST-LIST:START -->
-- [cpp-linter-hooks: The Most Complete pre-commit Solution for C/C++ Projects](https://shenxianpeng.github.io/en/posts/2026/cpp-linter-hooks/)
 - [Conventional Branch Official Skill Is Here—Install with One Command](https://shenxianpeng.github.io/en/posts/2026/conventional-branch-skill/)
 - [mkdocs-ng Maintenance Progress — v1.7.x Fix Summary and Next Steps](https://shenxianpeng.github.io/en/posts/2026/mkdocs-ng-update/)
 - [Building an AI Agent Inside Jira —— A Jira Copilot Implementation Guide](https://shenxianpeng.github.io/en/posts/2026/jira-ai-agent/)
@@ -71,13 +77,7 @@ Most of my projects are connected by one idea: help teams move from "we have man
 [zhihu]: https://www.zhihu.com/people/shenxianpeng
 [qrcode]: https://github.com/shenxianpeng/blog/blob/main/assets/img/qrcode.jpg
 [sponsor]: https://github.com/sponsors/shenxianpeng
-[cpp-linter]: https://github.com/cpp-linter/cpp-linter
-[cpp-linter-action]: https://github.com/cpp-linter/cpp-linter-action
-[cpp-linter-hooks]: https://github.com/cpp-linter/cpp-linter-hooks
 [commit-check]: https://github.com/commit-check/commit-check
-[commit-check-action]: https://github.com/commit-check/commit-check-action
-[commit-check-app]: https://github.com/commit-check/commit-check-app
-[commit-check-mcp]: https://github.com/commit-check/commit-check-mcp
 [conventional-branch]: https://github.com/conventional-branch/conventional-branch
 [devops-maturity]: https://github.com/devops-maturity/devops-maturity
 [explain-error-plugin]: https://github.com/jenkinsci/explain-error-plugin
@@ -86,16 +86,13 @@ Most of my projects are connected by one idea: help teams move from "we have man
 [mkdocs]: https://github.com/mkdocs-ng/mkdocs
 [mkdocs-material]: https://github.com/mkdocs-ng/mkdocs-material
 [cast-cli]: https://github.com/castops/cast-cli
-[cast-slice]: https://github.com/castops/cast-slice
 [atlassian-api-py]: https://github.com/shenxianpeng/atlassian-api-py
 [hadolint-pre-commit]: https://github.com/shenxianpeng/hadolint-pre-commit
 [py-eol]: https://github.com/shenxianpeng/py-eol
-[gnuplot-wheel]: https://github.com/shenxianpeng/gnuplot-wheel
 [jenkinsfilelint]: https://github.com/shenxianpeng/jenkinsfilelint
 [pipguard]: https://github.com/shenxianpeng/pipguard
 [repokeeper]: https://github.com/shenxianpeng/repokeeper
 [aion]: https://github.com/shenxianpeng/aion
-[atop]: https://github.com/shenxianpeng/atop
 [jenkinsci]: https://github.com/jenkinsci
 [pypa]: https://github.com/pypa
 [python]: https://github.com/python

--- a/README.md
+++ b/README.md
@@ -1,54 +1,54 @@
-### Hi 👋, I'm Xianpeng  
+### Hi, I'm Xianpeng
 
-<!--![GitHub Stars](https://img.shields.io/github/stars/shenxianpeng)-->
 ![Profile Views](https://komarev.com/ghpvc/?username=shenxianpeng)
 [![My PyPI packages](https://img.shields.io/badge/-PyPI-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages")](https://pypi.org/user/xpshen/)
 [![My PyPI packages stats](https://img.shields.io/badge/-PyPI_Stats-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages stats")][pypistats]
 [![Sponsor me on GitHub](https://img.shields.io/badge/GitHub-Sponsors-EA4AAA?style=flat&logo=githubsponsors "Sponsor me on GitHub")][sponsor]
 [![committers.top badge](https://user-badge.committers.top/lithuania_public/shenxianpeng.svg)](https://user-badge.committers.top/lithuania_public/shenxianpeng)
 
-<!--[💰][sponsor]-->
 [About](https://shenxianpeng.github.io/en/about/) | [Blog][blog] | [RSS][rss] | [Medium][medium] | [Dev.to][dev.to] | [WeChat][qrcode] | [Zhihu][zhihu]
 
 ---
 
-#### 🧩 Creator of
+I build open-source tools for **AI-assisted software delivery**: standards, code quality, CI feedback, supply-chain safety, failure diagnosis, and maintainer automation.
 
-- [**cpp-linter**][cpp-linter] – C/C++ linting solutions using clang-format and clang-tidy
-- [**commit-check**][commit-check] – Ensures consistent commit messages, branch names, and more
-- [**conventional-branch**][conventional-branch] – Git branch naming conventions for cleaner workflows
-- [**devops-maturity**][devops-maturity] – Specs and tools for assessing DevOps maturity
-- [**jenkinsci/explain-error-plugin**][explain-error-plugin] – Explains Jenkins job failures with AI
-- [**castops**][castops] – DevOps tools and automation for cast workflows
-- [**py-eol**][py-eol] – Track Python release & EOL timelines
-- [**atlassian-api-py**][atlassian-api-py] – Python library for Atlassian REST APIs
-- [**gnuplot-wheel**][gnuplot-wheel] – gnuplot Python wheel for easy installation
-- [**jenkinsfilelint**][jenkinsfilelint] – Lint Jenkinsfiles to catch syntax errors early
-- [**hadolint-pre-commit**][hadolint-pre-commit] – Hadolint Dockerfile linter as a pre-commit hook and PyPI package
-- [**pipguard**][pipguard] – Python supply chain security tool. Scan packages before installing them
-- [**repokeeper**][repokeeper] – AI-powered open source maintainer agent. Reads issues, writes code, opens PRs — 24/7
+Most of my projects are connected by one idea: help teams move from "we have many tools" to "we have an engineering system that guides, checks, explains, and improves itself."
 
-#### 🛠 Maintainer of
+#### The Solution Map
 
-- [**gitstats**][gitstats] - Generate insightful visual reports from Git
-- [**badgepy**][badgepy] - A Python library for creating GitHub-style badges
-- [**mkdocs**][mkdocs] - Project documentation with Markdown
-- [**mkdocs-material**][mkdocs-material] - Documentation that simply works
+| Stage | Problem | Projects |
+| --- | --- | --- |
+| Define engineering standards | Teams need consistent branch names, commit metadata, and contribution signals before work enters CI. | [conventional-branch][conventional-branch], [commit-check][commit-check], [commit-check-action][commit-check-action], [commit-check-app][commit-check-app], [commit-check-mcp][commit-check-mcp] |
+| Shift quality left | Developers should catch formatting, static analysis, Dockerfile, and Jenkinsfile issues before review. | [cpp-linter][cpp-linter], [cpp-linter-hooks][cpp-linter-hooks], [cpp-linter-action][cpp-linter-action], [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
+| Secure and sustain dependencies | Supply-chain and runtime-version risks should be visible before they become production problems. | [pipguard][pipguard], [py-eol][py-eol], [gnuplot-wheel][gnuplot-wheel] |
+| Understand engineering systems | Teams need readable signals about repository health, delivery maturity, and generated quality reports. | [gitstats][gitstats], [badgepy][badgepy], [devops-maturity][devops-maturity] |
+| Diagnose CI/CD failures with AI | Build failures should come with context, likely causes, and next actions instead of raw logs only. | [jenkinsci/explain-error-plugin][explain-error-plugin] |
+| Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion], [atop][atop] |
+| Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [castops/cast-slice][cast-slice], [atlassian-api-py][atlassian-api-py] |
 
----
+#### Featured Systems
 
-#### 🌍 Contributor to
+- [**cpp-linter**][cpp-linter] turns clang-format and clang-tidy into reusable developer workflows across CLI, GitHub Actions, pre-commit hooks, containers, and installable clang tools.
+- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to GitHub Actions, Apps, and MCP integrations.
+- [**Explain Error Plugin**][explain-error-plugin] brings AI failure explanation and auto-fix workflows into Jenkins, with support for multiple AI providers.
+- [**pipguard**][pipguard] blocks risky Python package installation paths before supply-chain attacks land.
+- [**repokeeper**][repokeeper] explores an AI-powered maintainer loop: read issues, reason about code, open pull requests, and keep OSS projects alive.
+- [**gitstats**][gitstats], [**badgepy**][badgepy], and [**devops-maturity**][devops-maturity] convert engineering activity into reports, badges, and maturity signals that teams can act on.
 
-- [**Jenkins**][jenkinsci] (member)
-- [**PyPA**][pypa] & [Python][python] ([merged PRs][python-prs])  
+#### Community and Stewardship
 
----
-
-🀄️ **WeChat:** [**shenxianpeng**][qrcode] – Sharing AI + DevOps practices and real-world insights
+- Member and contributor in the [**Jenkins**][jenkinsci] ecosystem, including [AI-powered Jenkins failure diagnosis][explain-error-plugin].
+- Contributor to [**PyPA**][pypa] and [**Python**][python] with [merged PRs][python-prs].
+- Maintainer of [**mkdocs-ng/mkdocs**][mkdocs] and [**mkdocs-ng/mkdocs-material**][mkdocs-material].
+- Maintainer of developer productivity projects such as [**gitstats**][gitstats] and [**badgepy**][badgepy].
 
 ---
 
-#### ✍️ Blog Posts
+**WeChat:** [**shenxianpeng**][qrcode] - sharing AI + DevOps practices and real-world engineering notes.
+
+---
+
+#### Writing
 
 <!-- BLOG-POST-LIST:START -->
 - [cpp-linter-hooks: The Most Complete pre-commit Solution for C/C++ Projects](https://shenxianpeng.github.io/en/posts/2026/cpp-linter-hooks/)
@@ -70,21 +70,23 @@
 [dev.to]: https://dev.to/shenxianpeng
 [zhihu]: https://www.zhihu.com/people/shenxianpeng
 [qrcode]: https://github.com/shenxianpeng/blog/blob/main/assets/img/qrcode.jpg
-[linkedin]: https://www.linkedin.com/in/xianpeng-shen/
-[gmail]: mailto:xianpeng.shen@gmail.com
-[paypal]: https://www.paypal.me/shenxianpeng
 [sponsor]: https://github.com/sponsors/shenxianpeng
-[ko-fi]: https://ko-fi.com/H2H85WC9L
-[cpp-linter]: https://github.com/cpp-linter
-[commit-check]: https://github.com/commit-check
-[conventional-branch]: https://github.com/conventional-branch
-[devops-maturity]: https://github.com/devops-maturity
+[cpp-linter]: https://github.com/cpp-linter/cpp-linter
+[cpp-linter-action]: https://github.com/cpp-linter/cpp-linter-action
+[cpp-linter-hooks]: https://github.com/cpp-linter/cpp-linter-hooks
+[commit-check]: https://github.com/commit-check/commit-check
+[commit-check-action]: https://github.com/commit-check/commit-check-action
+[commit-check-app]: https://github.com/commit-check/commit-check-app
+[commit-check-mcp]: https://github.com/commit-check/commit-check-mcp
+[conventional-branch]: https://github.com/conventional-branch/conventional-branch
+[devops-maturity]: https://github.com/devops-maturity/devops-maturity
 [explain-error-plugin]: https://github.com/jenkinsci/explain-error-plugin
 [gitstats]: https://github.com/shenxianpeng/gitstats
 [badgepy]: https://github.com/shenxianpeng/badgepy
 [mkdocs]: https://github.com/mkdocs-ng/mkdocs
 [mkdocs-material]: https://github.com/mkdocs-ng/mkdocs-material
-[castops]: https://github.com/castops
+[cast-cli]: https://github.com/castops/cast-cli
+[cast-slice]: https://github.com/castops/cast-slice
 [atlassian-api-py]: https://github.com/shenxianpeng/atlassian-api-py
 [hadolint-pre-commit]: https://github.com/shenxianpeng/hadolint-pre-commit
 [py-eol]: https://github.com/shenxianpeng/py-eol
@@ -92,9 +94,10 @@
 [jenkinsfilelint]: https://github.com/shenxianpeng/jenkinsfilelint
 [pipguard]: https://github.com/shenxianpeng/pipguard
 [repokeeper]: https://github.com/shenxianpeng/repokeeper
+[aion]: https://github.com/shenxianpeng/aion
+[atop]: https://github.com/shenxianpeng/atop
 [jenkinsci]: https://github.com/jenkinsci
 [pypa]: https://github.com/pypa
 [python]: https://github.com/python
 [python-prs]: https://github.com/pulls?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Apypa+user%3Apython
 [pypistats]: https://shenxianpeng.github.io/en/portfolio/pypistats/
-[jenkins-pr]: https://github.com/pulls?q=is%3Apr+author%3Ashenxianpeng+archived%3Afalse+is%3Amerged+user%3Ajenkinsci+user%3Ajenkins-infra

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 | Stage | Problem | Projects |
 | --- | --- | --- |
 | Define engineering standards | Teams need consistent branch names, commit metadata, and contribution signals before work enters CI. | [conventional-branch][conventional-branch], [commit-check][commit-check] |
-| Shift quality left | Developers should catch Jenkinsfile and Dockerfile issues before review. | [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
+| Shift quality left | Developers should catch C/C++, Jenkinsfile, and Dockerfile issues before review. | [cpp-linter-action][cpp-linter-action], [cpp-linter-hooks][cpp-linter-hooks], [jenkinsfilelint][jenkinsfilelint], [hadolint-pre-commit][hadolint-pre-commit] |
 | Secure and sustain dependencies | Supply-chain and runtime-version risks should be visible before they become production problems. | [pipguard][pipguard], [py-eol][py-eol] |
 | Understand engineering systems | Teams need readable signals about repository health, delivery maturity, and generated quality reports. | [gitstats][gitstats], [devops-maturity][devops-maturity] |
 | Diagnose CI/CD failures with AI | Build failures should come with context, likely causes, and next actions instead of raw logs only. | [jenkinsci/explain-error-plugin][explain-error-plugin] |
@@ -31,6 +31,7 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 #### Featured Systems
 
 - [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and AI-aware contribution workflows.
+- The [**cpp-linter**][cpp-linter-org] ecosystem brings C/C++ quality checks into GitHub Actions and pre-commit workflows, backed by maintained clang tools packaging across [static binaries][clang-tools-static-binaries], [Docker images][clang-tools-docker], and [Python wheels][clang-tools-wheel].
 - [**Explain Error Plugin**][explain-error-plugin] brings AI failure explanation and auto-fix workflows into Jenkins, with support for multiple AI providers.
 - [**pipguard**][pipguard] blocks risky Python package installation paths before supply-chain attacks land.
 - [**repokeeper**][repokeeper] explores an AI-powered maintainer loop: read issues, reason about code, open pull requests, and keep OSS projects alive.
@@ -58,6 +59,7 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 #### Writing
 
 <!-- BLOG-POST-LIST:START -->
+- [cpp-linter-hooks: The Most Complete pre-commit Solution for C/C++ Projects](https://shenxianpeng.github.io/en/posts/2026/cpp-linter-hooks/)
 - [Conventional Branch Official Skill Is Here—Install with One Command](https://shenxianpeng.github.io/en/posts/2026/conventional-branch-skill/)
 - [mkdocs-ng Maintenance Progress — v1.7.x Fix Summary and Next Steps](https://shenxianpeng.github.io/en/posts/2026/mkdocs-ng-update/)
 - [Building an AI Agent Inside Jira —— A Jira Copilot Implementation Guide](https://shenxianpeng.github.io/en/posts/2026/jira-ai-agent/)
@@ -77,6 +79,12 @@ Most of my projects are connected by one idea: help teams move from "AI generate
 [zhihu]: https://www.zhihu.com/people/shenxianpeng
 [qrcode]: https://github.com/shenxianpeng/blog/blob/main/assets/img/qrcode.jpg
 [sponsor]: https://github.com/sponsors/shenxianpeng
+[cpp-linter-org]: https://github.com/cpp-linter
+[cpp-linter-action]: https://github.com/cpp-linter/cpp-linter-action
+[cpp-linter-hooks]: https://github.com/cpp-linter/cpp-linter-hooks
+[clang-tools-static-binaries]: https://github.com/cpp-linter/clang-tools-static-binaries
+[clang-tools-docker]: https://github.com/cpp-linter/clang-tools-docker
+[clang-tools-wheel]: https://github.com/cpp-linter/clang-tools-wheel
 [commit-check]: https://github.com/commit-check/commit-check
 [conventional-branch]: https://github.com/conventional-branch/conventional-branch
 [devops-maturity]: https://github.com/devops-maturity/devops-maturity

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Hi, I'm Xianpeng
+### Hi, I'm Xianpeng 👋
 
 ![Profile Views](https://komarev.com/ghpvc/?username=shenxianpeng)
 [![My PyPI packages](https://img.shields.io/badge/-PyPI-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages")](https://pypi.org/user/xpshen/)
@@ -10,15 +10,9 @@
 
 ---
 
-I build open-source tools for **DevOps, CI/CD, developer workflows, and software delivery**.
+I build open-source tools for **DevOps, CI/CD, and software delivery** — collected as the **Open Delivery Stack**: standards, quality gates, CI feedback, dependency safety, and maintainer automation. AI is increasingly part of this: explaining failures, reviewing changes, and helping teams ship with evidence.
 
-My projects focus on a practical question: how can teams make software delivery more consistent, explainable, and maintainable?
-
-That work comes together as **Open Delivery Stack**: a pragmatic toolkit for standards, quality gates, CI feedback, dependency safety, engineering signals, failure diagnosis, and maintainer automation.
-
-AI is becoming part of that story, especially for explaining failures, assisting maintainers, reviewing changes, and improving how teams release software with evidence.
-
-#### What I Build
+#### 📦 What I Build
 
 | Area | Problem | Projects |
 | --- | --- | --- |
@@ -30,31 +24,18 @@ AI is becoming part of that story, especially for explaining failures, assisting
 | Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion] |
 | Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [atlassian-api-py][atlassian-api-py] |
 
-#### Featured Projects
+#### 🤖 AI & Current Focus
 
-- [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and contribution workflows.
-- The [**cpp-linter**][cpp-linter-org] ecosystem brings C/C++ quality checks into GitHub Actions and pre-commit workflows, backed by maintained clang tools packaging across [static binaries][clang-tools-static-binaries], [Docker images][clang-tools-docker], and [Python wheels][clang-tools-wheel].
-- [**pipguard**][pipguard] blocks risky Python package installation paths before supply-chain attacks land.
-- [**gitstats**][gitstats], [**badgepy**][badgepy], and [**devops-maturity**][devops-maturity] convert engineering activity into reports, badges, and maturity signals that teams can act on.
+- [**Explain Error Plugin**][explain-error-plugin] — AI-powered Jenkins failure diagnosis: causes, explanations, and suggested fixes instead of raw logs.
+- [**repokeeper**][repokeeper] / [**aion**][aion] — agent-based maintainer tooling for triaging issues, reasoning about code, and keeping repositories healthy.
+- **Release readiness & delivery evidence** — signals beyond test pass/fail: is this change ready to ship?
+- **AI change governance** — guardrails for AI-authored code so teams can review, trust, and maintain it over time.
 
-#### AI Experiments and Direction
+#### 👥 Community
 
-- [**Explain Error Plugin**][explain-error-plugin] applies AI to a concrete CI/CD pain point: turning Jenkins logs into causes, explanations, and suggested fixes.
-- [**repokeeper**][repokeeper] and [**aion**][aion] explore how agents can help maintainers triage work, reason about code, and keep repositories healthy.
-- My AI work is grounded in delivery workflows, not standalone demos: failure explanation, maintainer assistance, change review, and release evidence.
-
-#### Current Focus
-
-- **Release readiness** - making it easier to know whether a change is ready to ship, not just whether tests passed.
-- **Delivery evidence** - turning repository, CI, dependency, and review signals into evidence teams can use for audits, releases, and retrospectives.
-- **AI-generated change governance** - building guardrails for AI-authored code so teams can review, trust, and maintain it over time.
-
-#### Community and Stewardship
-
-- Member and contributor in the [**Jenkins**][jenkinsci] ecosystem, including [AI-powered Jenkins failure diagnosis][explain-error-plugin].
+- Maintainer and contributor in the [**Jenkins**][jenkinsci] ecosystem, including [AI-powered failure diagnosis][explain-error-plugin].
 - Contributor to [**PyPA**][pypa] ([merged PRs][pypa-prs]) and [**Python**][python] ([merged PRs][python-prs]).
-- Maintainer of [**mkdocs-ng/mkdocs**][mkdocs] and [**mkdocs-ng/mkdocs-material**][mkdocs-material].
-- Maintainer of developer productivity projects such as [**gitstats**][gitstats] and [**badgepy**][badgepy].
+- Maintainer of [**mkdocs-ng/mkdocs**][mkdocs], [**mkdocs-ng/mkdocs-material**][mkdocs-material], [**gitstats**][gitstats], and [**badgepy**][badgepy].
 
 ---
 
@@ -62,7 +43,7 @@ AI is becoming part of that story, especially for explaining failures, assisting
 
 ---
 
-#### Writing
+#### ✍️ Writing
 
 <!-- BLOG-POST-LIST:START -->
 - [cpp-linter-hooks: The Most Complete pre-commit Solution for C/C++ Projects](https://shenxianpeng.github.io/en/posts/2026/cpp-linter-hooks/)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 ---
 
-AI makes coding faster, but delivery still needs governance.
-
-I build open-source tools for **DevOps, CI/CD, developer workflows, and AI-era software delivery**.
+I build open-source tools for **DevOps, CI/CD, developer workflows, and software delivery**.
 
 My projects focus on a practical question: how can teams make software delivery more consistent, explainable, and maintainable?
 
@@ -20,7 +18,7 @@ That work comes together as **Open Delivery Stack**: a pragmatic toolkit for sta
 
 AI is becoming part of that story, especially for explaining failures, assisting maintainers, reviewing changes, and improving how teams release software with evidence.
 
-#### Software Delivery Toolkit
+#### What I Build
 
 | Area | Problem | Projects |
 | --- | --- | --- |
@@ -32,7 +30,7 @@ AI is becoming part of that story, especially for explaining failures, assisting
 | Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion] |
 | Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines. | [castops/cast-cli][cast-cli], [atlassian-api-py][atlassian-api-py] |
 
-#### Featured Tooling
+#### Featured Projects
 
 - [**commit-check**][commit-check] and [**conventional-branch**][conventional-branch] make repository metadata enforceable, from local conventions to CI policy and contribution workflows.
 - The [**cpp-linter**][cpp-linter-org] ecosystem brings C/C++ quality checks into GitHub Actions and pre-commit workflows, backed by maintained clang tools packaging across [static binaries][clang-tools-static-binaries], [Docker images][clang-tools-docker], and [Python wheels][clang-tools-wheel].


### PR DESCRIPTION
## Summary

- Reframes the profile README around a stronger but more grounded narrative: AI makes coding faster, but delivery still needs governance.
- Positions the work as DevOps, CI/CD, developer workflows, and AI-era software delivery, instead of implying every project is AI-assisted.
- Keeps **Open Delivery Stack** as the umbrella name while describing it as a pragmatic toolkit for standards, quality gates, CI feedback, dependency safety, engineering signals, failure diagnosis, and maintainer automation.
- Renames the main sections to `Software Delivery Toolkit` and `Featured Tooling`, and separates AI work into `AI Experiments and Direction`.
- Keeps the important `cpp-linter` ecosystem visible through `cpp-linter-action`, `cpp-linter-hooks`, and clang tools packaging work.
- Splits PyPA and Python merged-PR links so GitHub search does not misparse a combined `OR` query.

## Validation

- `git diff --check`
- Markdown reference scan for missing or unused reference definitions
- Reviewed the shared ChatGPT feedback and adjusted wording to avoid over-positioning older DevOps/tooling projects as AI projects