### PR TITLE
chore: hide immature projects, add WeChat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![My PyPI packages](https://img.shields.io/badge/-PyPI-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages")](https://pypi.org/user/xpshen/)
 [![My PyPI packages stats](https://img.shields.io/badge/-PyPI_Stats-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages stats")][pypistats]
 [![Sponsor me on GitHub](https://img.shields.io/badge/GitHub-Sponsors-EA4AAA?style=flat&logo=githubsponsors "Sponsor me on GitHub")][sponsor]
+[![WeChat](https://img.shields.io/badge/WeChat-shenxianpeng-07C160?style=flat&logo=wechat&logoColor=white "WeChat: shenxianpeng")][qrcode]
 [![committers.top badge](https://user-badge.committers.top/lithuania_public/shenxianpeng.svg)](https://user-badge.committers.top/lithuania_public/shenxianpeng)
 
 [About](https://shenxianpeng.github.io/en/about/) | [Blog][blog] | [RSS][rss] | [Medium][medium] | [Dev.to][dev.to] | [WeChat][qrcode] | [Zhihu][zhihu]
@@ -21,17 +22,15 @@ I build open-source tools for **DevOps, CI/CD, and software delivery** — colle
 | Secure and sustain dependencies | Supply-chain and runtime-version risks should be visible before they become production problems. | [pipguard][pipguard], [py-eol][py-eol] |
 | Understand engineering systems | Teams need readable signals about repository health, delivery maturity, and generated quality reports. | [gitstats][gitstats], [devops-maturity/devops-maturity][devops-maturity] |
 | Diagnose CI/CD failures with AI | Build failures should come with context, likely causes, and next actions instead of raw logs only. | [jenkinsci/explain-error-plugin][explain-error-plugin] |
-| Automate OSS maintenance | Maintainers need agents that can triage, reason, patch, and keep repositories moving. | [repokeeper][repokeeper], [aion][aion] |
 | Standardize team workflows | Platform work should turn one engineer's operational standards into repeatable team pipelines; cast-cli is now in maintenance mode as focus shifts to ODS. | [castops/cast-cli][cast-cli], [atlassian-api-py][atlassian-api-py] |
-| Govern delivery with machine evidence | AI writes code faster than governance can track; teams need machine-readable evidence at every stage. | [open-delivery-spec/spec][ods-spec], [open-delivery-spec/cli][ods-cli], [open-delivery-spec/validate-action][ods-validate-action] |
+| Govern delivery with machine evidence 🚧 | AI writes code faster than governance can track; teams need machine-readable evidence at every stage. | [open-delivery-spec/spec][ods-spec], [open-delivery-spec/cli][ods-cli], [open-delivery-spec/validate-action][ods-validate-action] |
 
 #### 🤖 AI & Current Focus
 
-- [**Open Delivery Spec (ODS)**][ods] — machine-readable delivery governance: spec, CLI, and CI validation so every commit-to-deploy stage leaves auditable evidence.
+- 🚧 [**Open Delivery Spec (ODS)**][ods] — machine-readable delivery governance: spec, CLI, and CI validation — every commit-to-deploy stage leaves auditable evidence. (actively building)
 - [**commit-check**][commit-check] — configurable Git commit and branch name validation for teams and CI pipelines.
 - [**cpp-linter**][cpp-linter-action] — C/C++ linting, formatting, and static analysis feedback directly in PRs and pre-commit.
 - [**Explain Error Plugin**][explain-error-plugin] — AI-powered Jenkins failure diagnosis: causes, explanations, and suggested fixes instead of raw logs.
-- [**repokeeper**][repokeeper] — agent-based maintainer tooling for triaging issues, reasoning about code, and keeping repositories healthy.
 
 #### 👥 Community
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![My PyPI packages](https://img.shields.io/badge/-PyPI-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages")](https://pypi.org/user/xpshen/)
 [![My PyPI packages stats](https://img.shields.io/badge/-PyPI_Stats-4B8BBE?style=flat&labelColor=306998&logo=pypi&logoColor=FFE873 "My PyPI packages stats")][pypistats]
 [![Sponsor me on GitHub](https://img.shields.io/badge/GitHub-Sponsors-EA4AAA?style=flat&logo=githubsponsors "Sponsor me on GitHub")][sponsor]
-[![WeChat](https://img.shields.io/badge/WeChat-shenxianpeng-07C160?style=flat&logo=wechat&logoColor=white "WeChat: shenxianpeng")][qrcode]
 [![committers.top badge](https://user-badge.committers.top/lithuania_public/shenxianpeng.svg)](https://user-badge.committers.top/lithuania_public/shenxianpeng)
 
 [About](https://shenxianpeng.github.io/en/about/) | [Blog][blog] | [RSS][rss] | [Medium][medium] | [Dev.to][dev.to] | [WeChat][qrcode] | [Zhihu][zhihu]


### PR DESCRIPTION
## Changes

### Removed
- **AIOn** and **RepoKeeper** — removed from both the project table and AI & Current Focus section (not mature enough yet)

### Updated
- **Open Delivery Spec (ODS)** — added 🚧 marker and "(actively building)" note in both table and AI focus section

### Added
- **WeChat badge** — green WeChat badge in the header badge row, linking to the QR code

### Summary
| Change | Before | After |
|---|---|---|
| Badge row | 5 badges | 6 badges (+WeChat) |
| Table rows | 7 | 6 (-Automate OSS maintenance) |
| AI Focus items | 5 | 4 (-repoKeeper, ODS marked 🚧) |