### PR TITLE
feat: show publish date next to each blog post

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -21,3 +21,4 @@ jobs:
           feed_list: "https://shenxianpeng.github.io/en/index.xml"
           max_post_count: 10
           date_format: mmm d, yyyy
+          template: "- [$title]($url) - $date$newline"


### PR DESCRIPTION
### 变更内容

在博客列表中的每条链接旁显示发布日期（如 `Jun 19, 2026`）。

### 修改文件

- `.github/workflows/blog-post.yml` — 添加 `template` 参数，使用 `$date` 变量在每条博客链接旁渲染日期

### 效果对比

**之前：**
```
- [From Demo to Production...](https://...)
```

**之后：**
```
- [From Demo to Production...](https://...) - Jun 19, 2026
```

> 关于相对时间（"一周前"、"一个月前"）：该 Action 底层的 `dateformat` 库不支持相对时间格式，故暂用绝对日期。如有需要可后续通过自定义 step 实现。