### PR TITLE
fix: add leading newline in blog post template

### DIFF
--- a/.github/workflows/blog-post.yml
+++ b/.github/workflows/blog-post.yml
@@ -21,4 +21,4 @@ jobs:
           feed_list: "https://shenxianpeng.github.io/en/index.xml"
           max_post_count: 10
           date_format: mmm d, yyyy
-          template: "- [$title]($url) - $date$newline"
+          template: "$newline- [$title]($url) - $date$newline"


### PR DESCRIPTION
The blog post list template is missing a leading `$newline`, causing the first post to appear right after `<!-- BLOG-POST-LIST:START -->` without a blank line break.

**Before:**
```
<!-- BLOG-POST-LIST:START -->- [Title](url) - Jun 8, 2026
- [Title](url) - May 31, 2026
<!-- BLOG-POST-LIST:END -->
```

**After:**
```
<!-- BLOG-POST-LIST:START -->
- [Title](url) - Jun 8, 2026
- [Title](url) - May 31, 2026
<!-- BLOG-POST-LIST:END -->
```